### PR TITLE
Fix parameters for repository changeset list action

### DIFF
--- a/lib/bitbucket_rest_api/repos/changesets.rb
+++ b/lib/bitbucket_rest_api/repos/changesets.rb
@@ -14,19 +14,19 @@ module BitBucket
     # List changesets on a repository
     #
     # = Parameters
-    # * <tt>:sha</tt>   Optional string. Sha or branch to start listing changesets from.
-    # * <tt>:path</tt>  Optional string. Only changesets containing this file path will be returned
+    # * <tt>:limit</tt> Optional integer. An integer representing how many changesets to return. You can specify a limit between 0 and 50.
+    # * <tt>:start</tt> Optional string. A hash value representing the earliest node to start with.
     #
     # = Examples
     #  bitbucket = BitBucket.new
-    #  bitbucket.repos.changesets.list 'user-name', 'repo-name', :sha => '...'
-    #  bitbucket.repos.changesets.list 'user-name', 'repo-name', :sha => '...' { |changeset| ... }
+    #  bitbucket.repos.changesets.list 'user-name', 'repo-name', :start => '...'
+    #  bitbucket.repos.changesets.list 'user-name', 'repo-name', :start => '...' { |changeset| ... }
     #
     def list(user_name, repo_name, params={})
       _update_user_repo_params(user_name, repo_name)
       _validate_user_repo_params(user, repo) unless user? && repo?
       normalize! params
-      filter! %w[ sha path], params
+      filter! %w[ limit start], params
 
       response = get_request("/repositories/#{user}/#{repo}/changesets", params)
       return response unless block_given?


### PR DESCRIPTION
The `Bitbucket::Repos::Changesets#list` action was using the parameters from the GitHub API instead of Bitbucket API (see the [Bitbucket API documentation](https://confluence.atlassian.com/display/BITBUCKET/changesets+Resource#changesetsResource-GETalistofchangesets) for details).

No testing suite is included with the project source code, so I was unable to write any tests to validate the changes. I did manually test it however. 
