### PR TITLE
Fixed a but that was causing the git2bit project (which uses this) to fail

### DIFF
--- a/lib/bitbucket_rest_api/issues.rb
+++ b/lib/bitbucket_rest_api/issues.rb
@@ -6,7 +6,7 @@ module BitBucket
 
     autoload_all 'bitbucket_rest_api/issues',
                  :Comments   => 'comments',
-                 :Components => 'Components',
+                 :Components => 'components',
                  :Milestones => 'milestones'
 
     VALID_ISSUE_PARAM_NAMES = %w[


### PR DESCRIPTION
Case sensitivity in file loading.
Fixes a downsteam error when issues are invoked: cannot load such file -- bitbucket_rest_api/issues/Components
