### PR TITLE
Many fixes

### DIFF
--- a/lib/bitbucket_rest_api/issues.rb
+++ b/lib/bitbucket_rest_api/issues.rb
@@ -67,7 +67,7 @@ module BitBucket
       # _merge_mime_type(:issue, params)
       assert_valid_values(VALID_ISSUE_PARAM_VALUES, params)
 
-      response = get_request("/repositories/#{user}/#{repo}/issues", params)
+      response = get_request("/repositories/#{user}/#{repo.downcase}/issues", params)
       return response.issues unless block_given?
       response.issues.each { |el| yield el }
     end
@@ -88,7 +88,7 @@ module BitBucket
       normalize! params
       # _merge_mime_type(:issue, params)
 
-      get_request("/repositories/#{user}/#{repo}/issues/#{issue_id}", params)
+      get_request("/repositories/#{user}/#{repo.downcase}/issues/#{issue_id}", params)
     end
 
     alias :find :get
@@ -141,7 +141,7 @@ module BitBucket
       filter! VALID_ISSUE_PARAM_NAMES, params
       assert_required_keys(%w[ title ], params)
 
-      post_request("/repositories/#{user}/#{repo}/issues/", params)
+      post_request("/repositories/#{user}/#{repo.downcase}/issues/", params)
     end
 
     # Edit an issue
@@ -191,7 +191,7 @@ module BitBucket
       # _merge_mime_type(:issue, params)
       filter! VALID_ISSUE_PARAM_NAMES, params
 
-      put_request("/repositories/#{user}/#{repo}/issues/#{issue_id}/", params)
+      put_request("/repositories/#{user}/#{repo.downcase}/issues/#{issue_id}/", params)
     end
 
   end # Issues

--- a/lib/bitbucket_rest_api/issues/comments.rb
+++ b/lib/bitbucket_rest_api/issues/comments.rb
@@ -27,7 +27,7 @@ module BitBucket
       normalize! params
       # _merge_mime_type(:issue_comment, params)
 
-      response = get_request("/repositories/#{user}/#{repo}/issues/#{issue_id}/comments/", params)
+      response = get_request("/repositories/#{user}/#{repo.downcase}/issues/#{issue_id}/comments/", params)
       return response unless block_given?
       response.each { |el| yield el }
     end
@@ -47,7 +47,7 @@ module BitBucket
       normalize! params
       # _merge_mime_type(:issue_comment, params)
 
-      get_request("/repositories/#{user}/#{repo}/issues/comments/#{comment_id}", params)
+      get_request("/repositories/#{user}/#{repo.downcase}/issues/comments/#{comment_id}", params)
     end
     alias :find :get
 
@@ -71,7 +71,7 @@ module BitBucket
       filter! VALID_ISSUE_COMMENT_PARAM_NAME, params
       assert_required_keys(%w[ content ], params)
 
-      post_request("/repositories/#{user}/#{repo}/issues/#{issue_id}/comments/", params)
+      post_request("/repositories/#{user}/#{repo.downcase}/issues/#{issue_id}/comments/", params)
     end
 
     # Edit a comment
@@ -94,7 +94,7 @@ module BitBucket
       filter! VALID_ISSUE_COMMENT_PARAM_NAME, params
       assert_required_keys(%w[ content ], params)
 
-      put_request("/repositories/#{user}/#{repo}/issues/comments/#{comment_id}")
+      put_request("/repositories/#{user}/#{repo.downcase}/issues/comments/#{comment_id}")
     end
 
     # Delete a comment
@@ -111,7 +111,7 @@ module BitBucket
       normalize! params
       # _merge_mime_type(:issue_comment, params)
 
-      delete_request("/repositories/#{user}/#{repo}/issues/comments/#{comment_id}", params)
+      delete_request("/repositories/#{user}/#{repo.downcase}/issues/comments/#{comment_id}", params)
     end
 
   end # Issues::Comments

--- a/lib/bitbucket_rest_api/issues/components.rb
+++ b/lib/bitbucket_rest_api/issues/components.rb
@@ -21,7 +21,7 @@ module BitBucket
       _validate_user_repo_params(user, repo) unless user? && repo?
       normalize! params
 
-      response = get_request("/repositories/#{user}/#{repo}/issues/components", params)
+      response = get_request("/repositories/#{user}/#{repo.downcase}/issues/components", params)
       return response unless block_given?
       response.each { |el| yield el }
     end
@@ -39,7 +39,7 @@ module BitBucket
       _validate_presence_of component_id
       normalize! params
 
-      get_request("/repositories/#{user}/#{repo}/issues/components/#{component_id}", params)
+      get_request("/repositories/#{user}/#{repo.downcase}/issues/components/#{component_id}", params)
     end
     alias :find :get
 
@@ -60,7 +60,7 @@ module BitBucket
       filter! VALID_COMPONENT_INPUTS, params
       assert_required_keys(VALID_COMPONENT_INPUTS, params)
 
-      post_request("/repositories/#{user}/#{repo}/issues/components", params)
+      post_request("/repositories/#{user}/#{repo.downcase}/issues/components", params)
     end
 
     # Update a component
@@ -82,7 +82,7 @@ module BitBucket
       filter! VALID_COMPONENT_INPUTS, params
       assert_required_keys(VALID_COMPONENT_INPUTS, params)
 
-      put_request("/repositories/#{user}/#{repo}/issues/components/#{component_id}", params)
+      put_request("/repositories/#{user}/#{repo.downcase}/issues/components/#{component_id}", params)
     end
     alias :edit :update
 
@@ -99,7 +99,7 @@ module BitBucket
       _validate_presence_of component_id
       normalize! params
 
-      delete_request("/repositories/#{user}/#{repo}/labels/components/#{component_id}", params)
+      delete_request("/repositories/#{user}/#{repo.downcase}/labels/components/#{component_id}", params)
     end
 
   end # Issues::Components

--- a/lib/bitbucket_rest_api/issues/milestones.rb
+++ b/lib/bitbucket_rest_api/issues/milestones.rb
@@ -24,7 +24,7 @@ module BitBucket
 
       normalize! params
 
-      response = get_request("/repositories/#{user}/#{repo}/issues/milestones", params)
+      response = get_request("/repositories/#{user}/#{repo.downcase}/issues/milestones", params)
       return response unless block_given?
       response.each { |el| yield el }
     end
@@ -42,7 +42,7 @@ module BitBucket
       _validate_presence_of milestone_id
       normalize! params
 
-      get_request("/repositories/#{user}/#{repo}/issues/milestones/#{milestone_id}", params)
+      get_request("/repositories/#{user}/#{repo.downcase}/issues/milestones/#{milestone_id}", params)
     end
     alias :find :get
 
@@ -63,7 +63,7 @@ module BitBucket
       filter! VALID_MILESTONE_INPUTS, params
       assert_required_keys(%w[ name ], params)
 
-      post_request("/repositories/#{user}/#{repo}/issues/milestones", params)
+      post_request("/repositories/#{user}/#{repo.downcase}/issues/milestones", params)
     end
 
     # Update a milestone
@@ -85,7 +85,7 @@ module BitBucket
       filter! VALID_MILESTONE_INPUTS, params
       assert_required_keys(%w[ name ], params)
 
-      put_request("/repositories/#{user}/#{repo}/issues/milestones/#{milestone_id}", params)
+      put_request("/repositories/#{user}/#{repo.downcase}/issues/milestones/#{milestone_id}", params)
     end
 
     # Delete a milestone
@@ -100,7 +100,7 @@ module BitBucket
       _validate_presence_of milestone_id
       normalize! params
 
-      delete_request("/repositories/#{user}/#{repo}/issues/milestones/#{milestone_id}", params)
+      delete_request("/repositories/#{user}/#{repo.downcase}/issues/milestones/#{milestone_id}", params)
     end
 
   end # Issues::Milestones

--- a/lib/bitbucket_rest_api/repos.rb
+++ b/lib/bitbucket_rest_api/repos.rb
@@ -67,7 +67,7 @@ module BitBucket
       _validate_user_repo_params(user, repo) unless (user? && repo?)
       normalize! params
 
-      response = get_request("/repositories/#{user}/#{repo}/branches/", params)
+      response = get_request("/repositories/#{user}/#{repo.downcase}/branches/", params)
       return response unless block_given?
       response.each { |el| yield el }
     end
@@ -138,7 +138,7 @@ module BitBucket
       normalize! params
       filter! VALID_REPO_OPTIONS, params
 
-      put_request("/repositories/#{user}/#{repo}/", DEFAULT_REPO_OPTIONS.merge(params))
+      put_request("/repositories/#{user}/#{repo.downcase}/", DEFAULT_REPO_OPTIONS.merge(params))
     end
 
     # Get a repository
@@ -152,7 +152,7 @@ module BitBucket
       _validate_user_repo_params(user, repo) unless user? && repo?
       normalize! params
 
-      get_request("/repositories/#{user}/#{repo}", params)
+      get_request("/repositories/#{user}/#{repo.downcase}", params)
     end
 
     alias :find :get
@@ -200,7 +200,7 @@ module BitBucket
       _validate_user_repo_params(user, repo) unless user? && repo?
       normalize! params
 
-      response = get_request("/repositories/#{user}/#{repo}/tags/", params)
+      response = get_request("/repositories/#{user}/#{repo.downcase}/tags/", params)
       return response unless block_given?
       response.each { |el| yield el }
     end

--- a/lib/bitbucket_rest_api/repos/changesets.rb
+++ b/lib/bitbucket_rest_api/repos/changesets.rb
@@ -28,7 +28,7 @@ module BitBucket
       normalize! params
       filter! %w[ limit start], params
 
-      response = get_request("/repositories/#{user}/#{repo}/changesets", params)
+      response = get_request("/repositories/#{user}/#{repo.downcase}/changesets", params)
       return response unless block_given?
       response.each { |el| yield el }
     end
@@ -46,7 +46,7 @@ module BitBucket
       _validate_presence_of sha
       normalize! params
 
-      get_request("/repositories/#{user}/#{repo}/changesets/#{sha}", params)
+      get_request("/repositories/#{user}/#{repo.downcase}/changesets/#{sha}", params)
     end
     alias :find :get
 

--- a/lib/bitbucket_rest_api/repos/following.rb
+++ b/lib/bitbucket_rest_api/repos/following.rb
@@ -15,7 +15,7 @@ module BitBucket
       _validate_user_repo_params(user, repo) unless user? && repo?
       normalize! params
 
-      response = get_request("/repositories/#{user}/#{repo}/followers/", params)
+      response = get_request("/repositories/#{user}/#{repo.downcase}/followers/", params)
       return response unless block_given?
       response.each { |el| yield el }
     end

--- a/lib/bitbucket_rest_api/repos/keys.rb
+++ b/lib/bitbucket_rest_api/repos/keys.rb
@@ -17,7 +17,7 @@ module BitBucket
       _validate_user_repo_params(user, repo) unless user? && repo?
       normalize! params
 
-      response = get_request("/repositories/#{user}/#{repo}/deploy-keys/", params)
+      response = get_request("/repositories/#{user}/#{repo.downcase}/deploy-keys/", params)
       return response unless block_given?
       response.each { |el| yield el }
     end
@@ -42,7 +42,7 @@ module BitBucket
       filter! VALID_KEY_PARAM_NAMES, params
       assert_required_keys(VALID_KEY_PARAM_NAMES, params)
 
-      post_request("/repositories/#{user}/#{repo}/deploy-keys/", params)
+      post_request("/repositories/#{user}/#{repo.downcase}/deploy-keys/", params)
     end
 
     # Edit a key
@@ -65,7 +65,7 @@ module BitBucket
       normalize! params
       filter! VALID_KEY_PARAM_NAMES, params
 
-      put_request("/repositories/#{user}/#{repo}/deploy-keys/#{key_id}", params)
+      put_request("/repositories/#{user}/#{repo.downcase}/deploy-keys/#{key_id}", params)
     end
 
     # Delete key
@@ -80,7 +80,7 @@ module BitBucket
       _validate_presence_of key_id
       normalize! params
 
-      delete_request("/repositories/#{user}/#{repo}/deploy-keys/#{key_id}", params)
+      delete_request("/repositories/#{user}/#{repo.downcase}/deploy-keys/#{key_id}", params)
     end
 
   end # Repos::Keys


### PR DESCRIPTION
- Fix a documentation bug: `:homepage` should be `:website` for BitBucket;
- Fix #5;
- When repository names show up in URL they should always be lowercased, or they won't work.
