### PR TITLE
Adding the ability to use Oauth if you supply the token consumer key and...

### DIFF
--- a/lib/bitbucket_rest_api/connection.rb
+++ b/lib/bitbucket_rest_api/connection.rb
@@ -42,7 +42,7 @@ module BitBucket
         #builder.use BitBucket::Request::Jsonize
         builder.use Faraday::Request::Multipart
         builder.use Faraday::Request::UrlEncoded
-        builder.use FaradayMiddleware::OAuth, {:consumer_key => client_id, :consumer_secret => client_secret, :token => oauth_token, :token_secret => oauth_secret} if oauth_token? and oauth_secret?
+        builder.use FaradayMiddleware::OAuth, {:consumer_key => client_id, :consumer_secret => client_secret, :token => oauth_token, :token_secret => oauth_secret} if client_id? and client_secret?
         builder.use BitBucket::Request::BasicAuth, authentication if basic_authed?
         builder.use FaradayMiddleware::EncodeJson
 


### PR DESCRIPTION
Since you were checking for the Oauth token and not the secret you weren't allowing the user to use their consumer key to use the api. This way they can use their consumer key or basic to consume the api. 
