### PR TITLE
Updated gemspec to make it work with faraday 0.9.0

### DIFF
--- a/bitbucket_rest_api.gemspec
+++ b/bitbucket_rest_api.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = %w[ lib ]
 
   gem.add_dependency 'hashie', '~> 2.0.5'
-  gem.add_dependency 'faraday', '~> 0.8.1'
+  gem.add_dependency 'faraday', '~> 0.9.0'
   gem.add_dependency 'multi_json', '~> 1.3'
   gem.add_dependency 'faraday_middleware', '~> 0.9.0'
   gem.add_dependency 'nokogiri', '>= 1.5.2'


### PR DESCRIPTION
After an update on faraday_middleware now it's possible to update to faraday 0.9.0
