### PR TITLE
Fixed deprecation warning with Faraday

### DIFF
--- a/lib/bitbucket_rest_api/connection.rb
+++ b/lib/bitbucket_rest_api/connection.rb
@@ -75,9 +75,9 @@ module BitBucket
     def stack(options={}, &block)
       @stack ||= begin
         if block_given?
-          Faraday::Builder.new(&block)
+          Faraday::RackBuilder.new(&block)
         else
-          Faraday::Builder.new(&default_middleware(options))
+          Faraday::RackBuilder.new(&default_middleware(options))
         end
       end
     end


### PR DESCRIPTION
Faraday::Builder is now Faraday::RackBuilder.
