### PR TITLE
Renamed `Repos:Commits#get` to `#list` for consistency and added alias

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ TAGS
 .tags_sorted_by_file
 coverage
 tags
+/.idea
+.ruby-gemset

--- a/bitbucket_rest_api.gemspec
+++ b/bitbucket_rest_api.gemspec
@@ -27,6 +27,6 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'simplecov', '~> 0.6.1'
   gem.add_development_dependency 'rake'
   gem.add_development_dependency 'bundler'
-  gem.add_development_dependency 'pry-debugger'
+  gem.add_development_dependency 'pry-byebug'
   gem.add_development_dependency 'mocha'
 end

--- a/lib/bitbucket_rest_api/repos/commits.rb
+++ b/lib/bitbucket_rest_api/repos/commits.rb
@@ -3,12 +3,38 @@
 module BitBucket
   class Repos::Commits < API
 
-    def get(user_name, repo_name)
+    VALID_KEY_PARAM_NAMES = %w(include exclude).freeze
+
+    # Gets the commit information associated with a repository. By default, this
+    # call returns all the commits across all branches, bookmarks, and tags. The
+    # newest commit is first.
+    #
+    # = Parameters
+    # *<tt>include</tt> - The SHA, branch, bookmark, or tag to include, for example, v10 or master. You can repeat the parameter multiple times.
+    # *<tt>exclude</tt> - The SHA, branch, bookmark, or tag to exclude, for example, v10 or master . You can repeat the parameter multiple times.
+    #
+    # = Examples
+    #  bitbucket = BitBucket.new
+    #  bitbucket.repos.commits.list 'user-name', 'repo-name'
+    #  bitbucket.repos.commits.list 'user-name', 'repo-name', 'master'
+    #  bitbucket.repos.commits.list 'user-name', 'repo-name' { |key| ... }
+    #  bitbucket.repos.commits.list 'user-name', 'repo-name', nil,
+    #    "include" => "feature-branch",
+    #    "exclude" =>  "master"
+    #
+    def list(user_name, repo_name, branchortag=nil, params={})
       _update_user_repo_params(user_name, repo_name)
       _validate_user_repo_params(user, repo) unless user? && repo?
-      get_request("/2.0/repositories/#{user}/#{repo.downcase}/commits")
+      normalize! params
+      filter! VALID_KEY_PARAM_NAMES, params
+
+      path = "/2.0/repositories/#{user}/#{repo.downcase}/commits"
+      path << "/#{branchortag}" if branchortag
+      response = get_request(path, params)
+      return response unless block_given?
+      response.each { |el| yield el }
     end
+    alias :all :list
 
-
-  end # Repos::Keys
+  end # Repos::Commits
 end # BitBucket

--- a/spec/bitbucket_rest_api/repos/commits_spec.rb
+++ b/spec/bitbucket_rest_api/repos/commits_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe BitBucket::Repos::Commits do
   let(:commits) { BitBucket::Repos::Commits.new }
 
-  describe '.get' do
+  describe '.list' do
     before do
       expect(commits).to receive(:request).with(
         :get,
@@ -14,7 +14,7 @@ describe BitBucket::Repos::Commits do
     end
 
     it 'should send a GET request for the commits belonging to the given repo' do
-      commits.get('mock_username', 'mock_repo')
+      commits.list('mock_username', 'mock_repo')
     end
   end
 end


### PR DESCRIPTION
- Added support for the `branchortag` optional parameter
- Added support for additional optional parameters according to
  official API documention
- Replaced `pry-debugger` with `pry-byebug` gem

https://confluence.atlassian.com/display/bitbucket/commits+or+commit+resource

I've been having a few fixes and updates in my fork for some weeks. I am sending them over since I saw that this gem got all lively again :smile:

I'll send the next ones shortly.