### PR TITLE
Renamed Repos::Sources#get to #list as it returns a list of files

### DIFF
--- a/lib/bitbucket_rest_api/repos/sources.rb
+++ b/lib/bitbucket_rest_api/repos/sources.rb
@@ -3,27 +3,35 @@
 module BitBucket
   class Repos::Sources < API
 
-    REQUIRED_COMMENT_PARAMS = %w[
-        body
-        changeset_id
-        line
-        path
-        position
-      ].freeze
-
-    # Gets a source of repo 
+    # Gets a list of the src in a repository.
     #
     # = Examples
     #  @bitbucket = BitBucket.new
-    #  @bitbucket.repos.sources.get 'user-name', 'repo-name', '6dcb09b5b57875f334f61aebed6', 'app/contorllers/')
+    #  @bitbucket.repos.sources.list 'user-name', 'repo-name', '6dcb09b5b57875f334f61aebed6', 'app/contorllers/')
     #
-    def get(user_name, repo_name, sha, path, params={})
+    def list(user_name, repo_name, sha, path)
       _update_user_repo_params(user_name, repo_name)
       _validate_user_repo_params(user, repo) unless user? && repo?
-      _validate_presence_of sha
-      normalize! params
+      _validate_presence_of(sha, path)
 
-      get_request("/1.0/repositories/#{user}/#{repo.downcase}/src/#{sha}/#{path}", params)
+      get_request("/1.0/repositories/#{user}/#{repo.downcase}/src/#{sha}/#{path}")
+    end
+    alias :all :list
+
+    # Gets information about an individual file. This method returns the file's
+    # size and contents.  If the file is encoded, this method returns the files
+    # encoding; Currently, Bitbucket supports only base64 encoding.
+    #
+    # = Examples
+    #  @bitbucket = BitBucket.new
+    #  @bitbucket.repos.sources.get 'user-name', 'repo-name', '6dcb09b5b57875f334f61aebed6', 'app/assets/images/logo.jpg')
+    #
+    def get(user_name, repo_name, sha, path)
+      _update_user_repo_params(user_name, repo_name)
+      _validate_user_repo_params(user, repo) unless user? && repo?
+      _validate_presence_of(sha, path)
+
+      get_request("/1.0/repositories/#{user}/#{repo.downcase}/raw/#{sha}/#{path}")
     end
     alias :find :get
 

--- a/spec/bitbucket_rest_api/repos/sources_spec.rb
+++ b/spec/bitbucket_rest_api/repos/sources_spec.rb
@@ -1,0 +1,77 @@
+require 'spec_helper'
+
+describe BitBucket::Repos::Sources do
+  let(:subject) { BitBucket::Repos::Sources.new }
+
+  describe '#list' do
+    context 'when some parameters are missing' do
+      it 'raises an error' do
+        expect do
+          subject.list(
+            'mock_username',
+            'mock_repo'
+          )
+        end.to raise_error(ArgumentError)
+      end
+    end
+
+    context 'when path parameter is empty' do
+      before do
+        expect(subject).to receive(:request).with(
+          :get,
+          '/1.0/repositories/mock_username/mock_repo/src/moch_sha/',
+          {},
+          {}
+        )
+      end
+
+      it 'sends a GET request for a list of all source files' do
+        subject.list('mock_username', 'mock_repo', 'moch_sha', '')
+      end
+    end
+
+    context 'when path parameter is defined' do
+      before do
+        expect(subject).to receive(:request).with(
+          :get,
+          '/1.0/repositories/mock_username/mock_repo/src/moch_sha/app/controller',
+          {},
+          {}
+        )
+      end
+
+      it 'send a GET request for a list of the source files under the specified path' do
+        subject.list('mock_username', 'mock_repo', 'moch_sha', 'app/controller')
+      end
+    end
+  end
+
+  describe '#get' do
+    context 'when some parameters are missing' do
+      it 'raises an error' do
+        expect do
+          subject.get(
+            'mock_username',
+            'mock_repo',
+            'moch_sha'
+          )
+        end.to raise_error(ArgumentError)
+      end
+    end
+
+    context 'when path parameter is defined' do
+      before do
+        expect(subject).to receive(:request).with(
+          :get,
+          '/1.0/repositories/mock_username/mock_repo/raw/moch_sha/app/assets/images/logo.jpg',
+          {},
+          {}
+        )
+      end
+
+      it "send a GET request for a source file's size and contents" do
+        subject.get('mock_username', 'mock_repo', 'moch_sha', 'app/assets/images/logo.jpg')
+      end
+    end
+  end
+end


### PR DESCRIPTION
Added a new `Repos::Sources#get` method, which returns the raw
contents of an individual file.