### PR TITLE
Add Content-Type: "application/json" on webhooks POST requests

### DIFF
--- a/lib/bitbucket_rest_api/repos.rb
+++ b/lib/bitbucket_rest_api/repos.rb
@@ -88,6 +88,10 @@ module BitBucket
       @default_reviewers ||= ApiFactory.new 'Repos::DefaultReviewers'
     end
 
+    def webhooks
+      @webhooks ||= ApiFactory.new 'Repos::Webhooks'
+    end
+
     # List branches
     #
     # = Examples

--- a/lib/bitbucket_rest_api/repos/keys.rb
+++ b/lib/bitbucket_rest_api/repos/keys.rb
@@ -42,7 +42,8 @@ module BitBucket
       filter! VALID_KEY_PARAM_NAMES, params
       assert_required_keys(VALID_KEY_PARAM_NAMES, params)
 
-      post_request("/1.0/repositories/#{user}/#{repo.downcase}/deploy-keys/", params)
+      options = { headers: { "Content-Type" => "application/json" } }
+      post_request("/1.0/repositories/#{user}/#{repo.downcase}/deploy-keys/", params, options)
     end
 
     # Edit a key

--- a/lib/bitbucket_rest_api/repos/webhooks.rb
+++ b/lib/bitbucket_rest_api/repos/webhooks.rb
@@ -34,7 +34,9 @@ module BitBucket
         'events'
       )
 
-      post_request("/2.0/repositories/#{user_name}/#{repo_name}/hooks", params)
+
+      options = { headers: { "Content-Type" => "application/json" } }
+      post_request("/2.0/repositories/#{user_name}/#{repo_name}/hooks", params, options)
     end
 
     def list(user_name, repo_name)
@@ -67,10 +69,11 @@ module BitBucket
         'events'
       )
 
+
+      options = { headers: { "Content-Type" => "application/json" } }
       put_request(
         "/2.0/repositories/#{user_name}/#{repo_name}/hooks/#{hook_uuid}",
-        params
-      )
+        params, options)
     end
 
     def delete(user_name, repo_name, hook_uuid)

--- a/spec/bitbucket_rest_api/repos/keys_spec.rb
+++ b/spec/bitbucket_rest_api/repos/keys_spec.rb
@@ -31,7 +31,7 @@ describe BitBucket::Repos::Keys do
         :post,
         '/1.0/repositories/mock_username/mock_repo/deploy-keys/',
         { 'key' => 'mock_ssh_key', 'label' => 'mock_label' },
-        {}
+        { headers: {"Content-Type"=>"application/json"} }
       )
     end
 

--- a/spec/bitbucket_rest_api/repos/webhooks_spec.rb
+++ b/spec/bitbucket_rest_api/repos/webhooks_spec.rb
@@ -112,7 +112,7 @@ describe BitBucket::Repos::Webhooks, wip: true do
         :post,
         '/2.0/repositories/mock_username/mock_repo/hooks',
         post_put_params,
-        {}
+        { headers: { "Content-Type" => "application/json" } }
       )
 
       subject.create(
@@ -218,7 +218,7 @@ describe BitBucket::Repos::Webhooks, wip: true do
         :put,
         '/2.0/repositories/mock_username/mock_repo/hooks/mock_uuid',
         post_put_params,
-        {}
+        { headers: { "Content-Type" => "application/json" } }
       )
 
       subject.edit(


### PR DESCRIPTION
As described on the Bitbucket documentation this is the way to go when there are nested objects.

https://confluence.atlassian.com/bitbucket/version-2-423626329.html#Version2-Supportedcontenttypes

This fixes this issue: #67 

TestStatus: [![Build Status](http://www.testributor.com/projects/103-bitbucket/status?branch=webhooks_api_fix)](http://www.testributor.com/projects/103-bitbucket/builds?branch=webhooks_api_fix)
