### PR TITLE
Use the 2.0 version of the Bitbucket API for repository lists

### DIFF
--- a/lib/bitbucket_rest_api/repos.rb
+++ b/lib/bitbucket_rest_api/repos.rb
@@ -219,20 +219,19 @@ module BitBucket
     #
     # = Examples
     #   bitbucket = BitBucket.new
-    #   bitbucket.repos.list :user => 'user-name'
+    #   bitbucket.repos.list :user => 'user-name', :role => 'owner'
     #   bitbucket.repos.list :user => 'user-name', { |repo| ... }
     def list(*args)
       params = args.extract_options!
       normalize! params
       _merge_user_into_params!(params) unless params.has_key?('user')
-      filter! %w[ user type ], params
+      params.merge!('pagelen' => 100) unless params.has_key?('pagelen')
+      
+      filter! %w[ user role pagelen ], params
 
-      response = #if (user_name = params.delete("user"))
-                 #  get_request("/1.0/users/#{user_name}", params)
-                 #else
-                   # For authenticated user
-                   get_request("/1.0/user/repositories", params)
-                 #end
+      response = get_request("/2.0/repositories", params)
+
+      response = response[:values]
       return response unless block_given?
       response.each { |el| yield el }
     end

--- a/spec/bitbucket_rest_api/repos_spec.rb
+++ b/spec/bitbucket_rest_api/repos_spec.rb
@@ -100,10 +100,10 @@ describe BitBucket::Repos do
     before do
       expect(repo).to receive(:request).with(
         :get,
-        '/1.0/user/repositories',
-        {},
+        '/2.0/repositories',
+        {"pagelen" => 100},
         {}
-      ).and_return(['repo1', 'repo2' ,'repo3'])
+      ).and_return(values: ['repo1', 'repo2' ,'repo3'])
     end
 
     # FIXME: this method belongs in the User class!


### PR DESCRIPTION
 This gives us the extra parameter of **role**, allowing us to filter the repository list by whether a user is an owner, contributor etc.

Specs updated and passing.

See https://confluence.atlassian.com/bitbucket/repositories-endpoint-423626330.html#repositoriesEndpoint-GETalistofallrepositories