### PR TITLE
Add api 2.0 commit endpoint wrapper

### DIFF
--- a/lib/bitbucket_rest_api/repos.rb
+++ b/lib/bitbucket_rest_api/repos.rb
@@ -13,6 +13,7 @@ module BitBucket
                  :Sources     => 'sources',
                  :Forks       => 'forks',
                  :Commits     => 'commits',
+                 :Commit      => 'commit',
                  :Download    => 'download',
                  :Webhooks    => 'webhooks',
                  :PullRequest => 'pull_request',
@@ -75,6 +76,11 @@ module BitBucket
     def commits
       @commits ||=ApiFactory.new 'Repos::Commits'
     end
+
+    def commit
+        @commit ||= ApiFactory.new 'Repos::Commit'
+    end
+
     def download
       @download ||=ApiFactory.new "Repos::Download"
     end

--- a/lib/bitbucket_rest_api/repos/commit.rb
+++ b/lib/bitbucket_rest_api/repos/commit.rb
@@ -1,0 +1,15 @@
+# encoding: utf-8
+
+module BitBucket
+  class Repos::Commit < API
+
+    def get(user_name, repo_name, revision)
+        _update_user_repo_params(user_name, repo_name)
+        _validate_user_repo_params(user, repo) unless user? && repo?
+
+        path = "/2.0/repositories/#{user}/#{repo.downcase}/commit/#{revision}"
+        get_request(path)
+    end
+
+  end # Repos::Commits
+end # BitBucket

--- a/spec/bitbucket_rest_api/repos/commit_spec.rb
+++ b/spec/bitbucket_rest_api/repos/commit_spec.rb
@@ -1,0 +1,20 @@
+require 'spec_helper'
+
+describe BitBucket::Repos::Commit do
+  let(:commit) { BitBucket::Repos::Commit.new }
+
+  describe '.get' do
+    before do
+      expect(commit).to receive(:request).with(
+        :get,
+        '/2.0/repositories/mock_username/mock_repo/commit/557557b267628ccc3060de76c16eb9c269e4576c',
+        {},
+        {}
+      )
+    end
+
+    it 'should send a GET request for the commit with given hash belonging to the given repo' do
+      commit.get('mock_username', 'mock_repo', '557557b267628ccc3060de76c16eb9c269e4576c')
+    end
+  end
+end

--- a/spec/bitbucket_rest_api/repos_spec.rb
+++ b/spec/bitbucket_rest_api/repos_spec.rb
@@ -149,6 +149,7 @@ describe BitBucket::Repos do
       expect(repo.keys).to be_a BitBucket::Repos::Keys
       expect(repo.following).to be_a BitBucket::Repos::Following
       expect(repo.commits).to be_a BitBucket::Repos::Commits
+      expect(repo.commit).to be_a BitBucket::Repos::Commit
       expect(repo.pull_request).to be_a BitBucket::Repos::PullRequest
       expect(repo.forks).to be_a BitBucket::Repos::Forks
       expect(repo.download).to be_a BitBucket::Repos::Download


### PR DESCRIPTION
Implemented a wrapper fro BitBucket API 2.0 Commit endpoint.