### PR TITLE
Update README.md to include example for OAuth2

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,12 @@ At this stage you can also supply various configuration parameters, such as `:us
 bitbucket = BitBucket.new oauth_token: 'request_token', oauth_secret: 'request_secret'
 ```
 
+or for OAuth2:
+
+```ruby
+bitbucket = BitBucket.new new_access_token: 'oauth2_access_token'
+```
+
 Alternatively, you can configure the BitBucket settings by passing a block:
 
 ```ruby


### PR DESCRIPTION
Couldn't figure out how to authenticate with OAuth2 until I found this comment in the issues: https://github.com/bitbucket-rest-api/bitbucket/issues/62#issuecomment-220730691 . This example should help with that.