### PR TITLE
Allow Faraday to follow redirects

### DIFF
--- a/lib/bitbucket_rest_api/connection.rb
+++ b/lib/bitbucket_rest_api/connection.rb
@@ -90,6 +90,8 @@ module BitBucket
       puts "OPTIONS:#{conn_options.inspect}" if ENV['DEBUG']
 
       @connection ||= Faraday.new(conn_options.merge(:builder => stack(options))) do |faraday|
+        faraday.use FaradayMiddleware::FollowRedirects
+        faraday.adapter :net_http
         faraday.response :logger if ENV['DEBUG']
       end
     end


### PR DESCRIPTION
Apparently some BitBucket endpoints will serve a 302 redirect. This was causing an error.

For example:

```
irb(main):035:0> pp b.pull_requests.diff('my_user', 'my_repo', '1')
RuntimeError: can't modify frozen NilClass
	from /Users/wboynton/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bitbucket_rest_api-0.1.7/lib/bitbucket_rest_api/response/helpers.rb:17:in `block in on_complete'
	from /Users/wboynton/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bitbucket_rest_api-0.1.7/lib/bitbucket_rest_api/response/helpers.rb:17:in `instance_eval'
	from /Users/wboynton/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bitbucket_rest_api-0.1.7/lib/bitbucket_rest_api/response/helpers.rb:17:in `on_complete'
	from /Users/wboynton/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/faraday-0.9.2/lib/faraday/response.rb:9:in `block in call'
	from /Users/wboynton/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/faraday-0.9.2/lib/faraday/response.rb:57:in `on_complete'
	from /Users/wboynton/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/faraday-0.9.2/lib/faraday/response.rb:8:in `call'
	from /Users/wboynton/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/faraday_middleware-0.9.2/lib/faraday_middleware/request/encode_json.rb:23:in `call'
	from /Users/wboynton/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bitbucket_rest_api-0.1.7/lib/bitbucket_rest_api/request/basic_auth.rb:14:in `call'
	from /Users/wboynton/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/faraday-0.9.2/lib/faraday/request/url_encoded.rb:15:in `call'
	from /Users/wboynton/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/faraday-0.9.2/lib/faraday/request/multipart.rb:14:in `call'
	from /Users/wboynton/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/faraday-0.9.2/lib/faraday/rack_builder.rb:139:in `build_response'
	from /Users/wboynton/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/faraday-0.9.2/lib/faraday/connection.rb:377:in `run_request'
	from /Users/wboynton/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/faraday-0.9.2/lib/faraday/connection.rb:140:in `get'
	from /Users/wboynton/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bitbucket_rest_api-0.1.7/lib/bitbucket_rest_api/request.rb:42:in `request'
	from /Users/wboynton/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/bitbucket_rest_api-0.1.7/lib/bitbucket_rest_api/repos/pull_request.rb:100:in `diff'
	from (irb):35
	from /Users/wboynton/.rbenv/versions/2.4.1/bin/irb:11:in `<main>'
```

Following the directions from [this Faraday issue](https://github.com/lostisland/faraday_middleware/issues/32), it seemed like all I needed to do was use the `FaradayMiddleware::FollowRedirects` and explicitly mount an adapter. I did that and the same code began working. You can scrutinize and change this at your leisure, but `GET`ting data from (at least) that endpoint will be broken until Faraday is using redirects.