### PR TITLE
Use the 2.0 endpoint for branches too

### DIFF
--- a/lib/bitbucket_rest_api/repos.rb
+++ b/lib/bitbucket_rest_api/repos.rb
@@ -112,7 +112,7 @@ module BitBucket
       _validate_user_repo_params(user, repo) unless (user? && repo?)
       normalize! params
 
-      response = get_request("/1.0/repositories/#{user}/#{repo.downcase}/branches/", params)
+      response = get_request("/2.0/repositories/#{user}/#{repo.downcase}/refs/branches/", params)
       return response unless block_given?
       response.each { |el| yield el }
     end


### PR DESCRIPTION
The response is a bit different now (as are most v2.0 endpoints, probably).

https://developer.atlassian.com/bitbucket/api/2/reference/resource/repositories/%7Busername%7D/%7Brepo_slug%7D/refs/branches