### PR TITLE
Fix broken specs

### DIFF
--- a/bitbucket_rest_api.gemspec
+++ b/bitbucket_rest_api.gemspec
@@ -30,5 +30,4 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'rake'
   gem.add_development_dependency 'bundler'
   gem.add_development_dependency 'pry-byebug'
-  gem.add_development_dependency 'mocha'
 end

--- a/spec/bitbucket_rest_api/request_spec.rb
+++ b/spec/bitbucket_rest_api/request_spec.rb
@@ -22,7 +22,7 @@ describe BitBucket::Request do
           'Accept' => '*/*',
           'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
           'Authorization' => 'Bearer 12345',
-          'User-Agent' => 'Faraday v0.9.2'
+          'User-Agent' => "Faraday v#{Faraday::VERSION}"
           })
 
         fake_api.new.request(:get, '/1.0/endpoint', {}, {})
@@ -35,7 +35,7 @@ describe BitBucket::Request do
             'Accept' => '*/*',
             'Content-Type'=>'application/x-www-form-urlencoded',
             'Authorization' => 'Bearer 12345',
-            'User-Agent' => 'Faraday v0.9.2'
+            'User-Agent' => "Faraday v#{Faraday::VERSION}"
           })
 
         fake_api.new.request(:put, '/1.0/endpoint', { 'data' => { 'key' => 'value'} }, {})
@@ -48,7 +48,7 @@ describe BitBucket::Request do
             'Accept' => '*/*',
             'Content-Type'=>'application/x-www-form-urlencoded',
             'Authorization' => 'Bearer 12345',
-            'User-Agent' => 'Faraday v0.9.2'
+            'User-Agent' => "Faraday v#{Faraday::VERSION}"
           })
 
         fake_api.new.request(:patch, '/1.0/endpoint', { 'data' => { 'key' => 'value'} }, {})
@@ -59,7 +59,7 @@ describe BitBucket::Request do
          with(:headers => {
           'Accept' => '*/*',
           'Authorization' => 'Bearer 12345',
-          'User-Agent' => 'Faraday v0.9.2'
+          'User-Agent' => "Faraday v#{Faraday::VERSION}"
           })
         fake_api.new.request(:delete, '/1.0/endpoint', {}, {})
       end
@@ -71,7 +71,7 @@ describe BitBucket::Request do
             'Accept' => '*/*',
             'Content-Type'=>'application/x-www-form-urlencoded',
             'Authorization' => 'Bearer 12345',
-            'User-Agent' => 'Faraday v0.9.2'
+            'User-Agent' => "Faraday v#{Faraday::VERSION}"
           })
 
         fake_api.new.request(:post, '/1.0/endpoint', { 'data' => { 'key' => 'value'} }, {})

--- a/spec/bitbucket_rest_api/request_spec.rb
+++ b/spec/bitbucket_rest_api/request_spec.rb
@@ -2,8 +2,19 @@ require 'spec_helper'
 require 'bitbucket_rest_api/request'
 
 describe BitBucket::Request do
-  let(:fake_api) { (Class.new { include BitBucket::Request })}
-  let(:faraday_connection) { Faraday.new(:url => 'https://api.bitbucket.org') }
+  let(:fake_api) do
+    Class.new do
+      include BitBucket::Request
+
+      def connection(*args)
+        Faraday.new(:url => 'https://api.bitbucket.org')
+      end
+
+      def new_access_token
+        "12345"
+      end
+    end
+  end
 
   describe "request" do
     it "raises an ArgumentError if an unsupported HTTP verb is used" do
@@ -11,11 +22,6 @@ describe BitBucket::Request do
     end
 
     context "with a connection" do
-      before do
-        (fake_api).any_instance.stubs(:connection).returns(faraday_connection)
-        (fake_api).any_instance.stubs(:new_access_token).returns("12345")
-      end
-
       it "supports get" do
         stub_request(:get, "https://api.bitbucket.org/1.0/endpoint").
          with(:headers => {

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,7 +10,6 @@ require 'bitbucket_rest_api'
 RSpec.configure do |config|
   config.expect_with :rspec do |expectations|
     expectations.include_chain_clauses_in_custom_matcher_descriptions = true
-    config.mock_with :mocha
   end
 
   config.mock_with :rspec do |mocks|


### PR DESCRIPTION
## Issue

`request_spec` is failing with 
```
Mocha::NotInitializedError:
       Mocha methods cannot be used outside the context of a test
```

## Fix
 - Remove hard-coded `faraday` version
 - Remove stub and define methods in `Class.new` block, thereby removing the need for `mocha`
 - Remove mocha 

