### PR TITLE
Bump faraday, faraday_middleware and Bitbucket API versions

### DIFF
--- a/bitbucket_rest_api.gemspec
+++ b/bitbucket_rest_api.gemspec
@@ -16,9 +16,9 @@ Gem::Specification.new do |gem|
   gem.require_paths = %w[ lib ]
 
   gem.add_dependency 'hashie'
-  gem.add_dependency 'faraday', '~> 0.17.1'
+  gem.add_dependency 'faraday', '~> 1'
   gem.add_dependency 'multi_json',  '>= 1.7.5', '< 2.0'
-  gem.add_dependency 'faraday_middleware', '~> 0.9.0'
+  gem.add_dependency 'faraday_middleware', '~> 1'
   gem.add_dependency 'nokogiri', '>= 1.5.2'
   gem.add_dependency 'simple_oauth'
 

--- a/bitbucket_rest_api.gemspec
+++ b/bitbucket_rest_api.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = %w[ lib ]
 
   gem.add_dependency 'hashie'
-  gem.add_dependency 'faraday', '~> 0.9.0'
+  gem.add_dependency 'faraday', '~> 0.17.1'
   gem.add_dependency 'multi_json',  '>= 1.7.5', '< 2.0'
   gem.add_dependency 'faraday_middleware', '~> 0.9.0'
   gem.add_dependency 'nokogiri', '>= 1.5.2'

--- a/lib/bitbucket_rest_api.rb
+++ b/lib/bitbucket_rest_api.rb
@@ -72,6 +72,7 @@ module BitBucket
                :Result          => 'result',
 
                :Repos           => 'repos',
+               :Workspaces      => 'workspaces',
                #:Error           => 'error',
                :Issues          => 'issues',
                :User            => 'user',

--- a/lib/bitbucket_rest_api/client.rb
+++ b/lib/bitbucket_rest_api/client.rb
@@ -33,6 +33,10 @@ module BitBucket
     end
     alias :repositories :repos
 
+    def workspaces(options = {})
+      @workspaces ||= ApiFactory.new 'Workspaces', options
+    end
+
     def search(options = {})
       raise "Unimplemented"
       #@search ||= ApiFactory.new 'Search', options

--- a/lib/bitbucket_rest_api/invitations.rb
+++ b/lib/bitbucket_rest_api/invitations.rb
@@ -8,7 +8,7 @@ module BitBucket
       _validate_presence_of emailaddress
       perm ||= "write"
 
-      post_request("/1.0/invitations/#{user}/#{repo.downcase}/#{emailaddress}",
+      post_request("/2.0/invitations/#{user}/#{repo.downcase}/#{emailaddress}",
                    permission: perm)
     end
   end

--- a/lib/bitbucket_rest_api/issues.rb
+++ b/lib/bitbucket_rest_api/issues.rb
@@ -82,7 +82,7 @@ module BitBucket
       # _merge_mime_type(:issue, params)
       assert_valid_values(VALID_ISSUE_PARAM_VALUES, params)
 
-      response = get_request("/1.0/repositories/#{user}/#{repo.downcase}/issues", params)
+      response = get_request("/2.0/repositories/#{user}/#{repo.downcase}/issues", params)
       return response.issues unless block_given?
       response.issues.each { |el| yield el }
     end
@@ -103,7 +103,7 @@ module BitBucket
       normalize! params
       # _merge_mime_type(:issue, params)
 
-      get_request("/1.0/repositories/#{user}/#{repo.downcase}/issues/#{issue_id}", params)
+      get_request("/2.0/repositories/#{user}/#{repo.downcase}/issues/#{issue_id}", params)
     end
 
     alias :find :get
@@ -122,7 +122,7 @@ module BitBucket
       normalize! params
       # _merge_mime_type(:issue, params)
 
-      delete_request("/1.0/repositories/#{user}/#{repo}/issues/#{issue_id}", params)
+      delete_request("/2.0/repositories/#{user}/#{repo}/issues/#{issue_id}", params)
     end
 
     # Create an issue
@@ -173,7 +173,7 @@ module BitBucket
       filter! VALID_ISSUE_PARAM_NAMES, params
       assert_required_keys(%w[ title ], params)
 
-      post_request("/1.0/repositories/#{user}/#{repo.downcase}/issues/", params)
+      post_request("/2.0/repositories/#{user}/#{repo.downcase}/issues/", params)
     end
 
     # Edit an issue
@@ -223,7 +223,7 @@ module BitBucket
       # _merge_mime_type(:issue, params)
       filter! VALID_ISSUE_PARAM_NAMES, params
 
-      put_request("/1.0/repositories/#{user}/#{repo.downcase}/issues/#{issue_id}/", params)
+      put_request("/2.0/repositories/#{user}/#{repo.downcase}/issues/#{issue_id}/", params)
     end
 
   end # Issues

--- a/lib/bitbucket_rest_api/issues.rb
+++ b/lib/bitbucket_rest_api/issues.rb
@@ -73,7 +73,7 @@ module BitBucket
     #  bitbucket = BitBucket.new :user => 'user-name', :repo => 'repo-name'
     #  bitbucket.issues.list_repo :filter => 'kind=bug&kind=enhancement'
     #
-    def list_repo(user_name, repo_name, params={ })
+    def list_repo(user_name, repo_name, params = {})
       _update_user_repo_params(user_name, repo_name)
       _validate_user_repo_params(user, repo) unless user? && repo?
 
@@ -83,8 +83,8 @@ module BitBucket
       assert_valid_values(VALID_ISSUE_PARAM_VALUES, params)
 
       response = get_request("/2.0/repositories/#{user}/#{repo.downcase}/issues", params)
-      return response.issues unless block_given?
-      response.issues.each { |el| yield el }
+      return response unless block_given?
+      response["values"].each { |el| yield el }
     end
 
     alias :list_repository :list_repo

--- a/lib/bitbucket_rest_api/issues/comments.rb
+++ b/lib/bitbucket_rest_api/issues/comments.rb
@@ -27,7 +27,7 @@ module BitBucket
       normalize! params
       # _merge_mime_type(:issue_comment, params)
 
-      response = get_request("/1.0/repositories/#{user}/#{repo.downcase}/issues/#{issue_id}/comments/", params)
+      response = get_request("/2.0/repositories/#{user}/#{repo.downcase}/issues/#{issue_id}/comments/", params)
       return response unless block_given?
       response.each { |el| yield el }
     end
@@ -47,7 +47,7 @@ module BitBucket
       normalize! params
       # _merge_mime_type(:issue_comment, params)
 
-      get_request("/1.0/repositories/#{user}/#{repo.downcase}/issues/comments/#{comment_id}", params)
+      get_request("/2.0/repositories/#{user}/#{repo.downcase}/issues/comments/#{comment_id}", params)
     end
     alias :find :get
 
@@ -71,7 +71,7 @@ module BitBucket
       filter! VALID_ISSUE_COMMENT_PARAM_NAME, params
       assert_required_keys(%w[ content ], params)
 
-      post_request("/1.0/repositories/#{user}/#{repo.downcase}/issues/#{issue_id}/comments/", params)
+      post_request("/2.0/repositories/#{user}/#{repo.downcase}/issues/#{issue_id}/comments/", params)
     end
 
     # Edit a comment
@@ -94,7 +94,7 @@ module BitBucket
       filter! VALID_ISSUE_COMMENT_PARAM_NAME, params
       assert_required_keys(%w[ content ], params)
 
-      put_request("/1.0/repositories/#{user}/#{repo.downcase}/issues/comments/#{comment_id}", params)
+      put_request("/2.0/repositories/#{user}/#{repo.downcase}/issues/comments/#{comment_id}", params)
     end
 
     # Delete a comment
@@ -111,7 +111,7 @@ module BitBucket
       normalize! params
       # _merge_mime_type(:issue_comment, params)
 
-      delete_request("/1.0/repositories/#{user}/#{repo.downcase}/issues/comments/#{comment_id}", params)
+      delete_request("/2.0/repositories/#{user}/#{repo.downcase}/issues/comments/#{comment_id}", params)
     end
 
   end # Issues::Comments

--- a/lib/bitbucket_rest_api/issues/components.rb
+++ b/lib/bitbucket_rest_api/issues/components.rb
@@ -21,7 +21,7 @@ module BitBucket
       _validate_user_repo_params(user, repo) unless user? && repo?
       normalize! params
 
-      response = get_request("/1.0/repositories/#{user}/#{repo.downcase}/issues/components", params)
+      response = get_request("/2.0/repositories/#{user}/#{repo.downcase}/issues/components", params)
       return response unless block_given?
       response.each { |el| yield el }
     end
@@ -39,7 +39,7 @@ module BitBucket
       _validate_presence_of component_id
       normalize! params
 
-      get_request("/1.0/repositories/#{user}/#{repo.downcase}/issues/components/#{component_id}", params)
+      get_request("/2.0/repositories/#{user}/#{repo.downcase}/issues/components/#{component_id}", params)
     end
     alias :find :get
 
@@ -60,7 +60,7 @@ module BitBucket
       filter! VALID_COMPONENT_INPUTS, params
       assert_required_keys(VALID_COMPONENT_INPUTS, params)
 
-      post_request("/1.0/repositories/#{user}/#{repo.downcase}/issues/components", params)
+      post_request("/2.0/repositories/#{user}/#{repo.downcase}/issues/components", params)
     end
 
     # Update a component
@@ -82,7 +82,7 @@ module BitBucket
       filter! VALID_COMPONENT_INPUTS, params
       assert_required_keys(VALID_COMPONENT_INPUTS, params)
 
-      put_request("/1.0/repositories/#{user}/#{repo.downcase}/issues/components/#{component_id}", params)
+      put_request("/2.0/repositories/#{user}/#{repo.downcase}/issues/components/#{component_id}", params)
     end
     alias :edit :update
 
@@ -99,7 +99,7 @@ module BitBucket
       _validate_presence_of component_id
       normalize! params
 
-      delete_request("/1.0/repositories/#{user}/#{repo.downcase}/issues/components/#{component_id}", params)
+      delete_request("/2.0/repositories/#{user}/#{repo.downcase}/issues/components/#{component_id}", params)
     end
 
   end # Issues::Components

--- a/lib/bitbucket_rest_api/issues/milestones.rb
+++ b/lib/bitbucket_rest_api/issues/milestones.rb
@@ -24,7 +24,7 @@ module BitBucket
 
       normalize! params
 
-      response = get_request("/1.0/repositories/#{user}/#{repo.downcase}/issues/milestones", params)
+      response = get_request("/2.0/repositories/#{user}/#{repo.downcase}/issues/milestones", params)
       return response unless block_given?
       response.each { |el| yield el }
     end
@@ -42,7 +42,7 @@ module BitBucket
       _validate_presence_of milestone_id
       normalize! params
 
-      get_request("/1.0/repositories/#{user}/#{repo.downcase}/issues/milestones/#{milestone_id}", params)
+      get_request("/2.0/repositories/#{user}/#{repo.downcase}/issues/milestones/#{milestone_id}", params)
     end
     alias :find :get
 
@@ -63,7 +63,7 @@ module BitBucket
       filter! VALID_MILESTONE_INPUTS, params
       assert_required_keys(%w[ name ], params)
 
-      post_request("/1.0/repositories/#{user}/#{repo.downcase}/issues/milestones", params)
+      post_request("/2.0/repositories/#{user}/#{repo.downcase}/issues/milestones", params)
     end
 
     # Update a milestone
@@ -85,7 +85,7 @@ module BitBucket
       filter! VALID_MILESTONE_INPUTS, params
       assert_required_keys(%w[ name ], params)
 
-      put_request("/1.0/repositories/#{user}/#{repo.downcase}/issues/milestones/#{milestone_id}", params)
+      put_request("/2.0/repositories/#{user}/#{repo.downcase}/issues/milestones/#{milestone_id}", params)
     end
 
     # Delete a milestone
@@ -100,7 +100,7 @@ module BitBucket
       _validate_presence_of milestone_id
       normalize! params
 
-      delete_request("/1.0/repositories/#{user}/#{repo.downcase}/issues/milestones/#{milestone_id}", params)
+      delete_request("/2.0/repositories/#{user}/#{repo.downcase}/issues/milestones/#{milestone_id}", params)
     end
 
   end # Issues::Milestones

--- a/lib/bitbucket_rest_api/repos.rb
+++ b/lib/bitbucket_rest_api/repos.rb
@@ -122,7 +122,7 @@ module BitBucket
       _validate_user_repo_params(user, repo) unless (user? && repo?)
       normalize! params
 
-      response = get_request("/2.0/repositories/#{user}/#{repo.downcase}/branches/", params)
+      response = get_request("/2.0/repositories/#{user}/#{repo.downcase}/refs/branches/", params)
       return response unless block_given?
       response.each { |el| yield el }
     end

--- a/lib/bitbucket_rest_api/repos.rb
+++ b/lib/bitbucket_rest_api/repos.rb
@@ -112,7 +112,7 @@ module BitBucket
       _validate_user_repo_params(user, repo) unless (user? && repo?)
       normalize! params
 
-      response = get_request("/1.0/repositories/#{user}/#{repo.downcase}/branches/", params)
+      response = get_request("/2.0/repositories/#{user}/#{repo.downcase}/branches/", params)
       return response unless block_given?
       response.each { |el| yield el }
     end
@@ -154,7 +154,7 @@ module BitBucket
       assert_required_keys(%w[ name ], params)
 
       # Requires authenticated user
-      post_request("/1.0/repositories/", DEFAULT_REPO_OPTIONS.merge(params))
+      post_request("/2.0/repositories/", DEFAULT_REPO_OPTIONS.merge(params))
     end
 
     # Edit a repository
@@ -184,7 +184,7 @@ module BitBucket
       normalize! params
       filter! VALID_REPO_OPTIONS, params
 
-      put_request("/1.0/repositories/#{user}/#{repo.downcase}/", DEFAULT_REPO_OPTIONS.merge(params))
+      put_request("/2.0/repositories/#{user}/#{repo.downcase}/", DEFAULT_REPO_OPTIONS.merge(params))
     end
 
     # Get a repository
@@ -198,7 +198,7 @@ module BitBucket
       _validate_user_repo_params(user, repo) unless user? && repo?
       normalize! params
 
-      get_request("/1.0/repositories/#{user}/#{repo.downcase}", params)
+      get_request("/2.0/repositories/#{user}/#{repo.downcase}", params)
     end
 
     alias :find :get
@@ -214,7 +214,7 @@ module BitBucket
       _update_user_repo_params(user_name, repo_name)
       _validate_user_repo_params(user, repo) unless user? && repo?
 
-      delete_request("/1.0/repositories/#{user}/#{repo.downcase}")
+      delete_request("/2.0/repositories/#{user}/#{repo.downcase}")
     end
 
     # List repositories for the authenticated user
@@ -259,7 +259,7 @@ module BitBucket
       _validate_user_repo_params(user, repo) unless user? && repo?
       normalize! params
 
-      response = get_request("/1.0/repositories/#{user}/#{repo.downcase}/tags/", params)
+      response = get_request("/2.0/repositories/#{user}/#{repo.downcase}/tags/", params)
       return response unless block_given?
       response.each { |el| yield el }
     end

--- a/lib/bitbucket_rest_api/repos/branch_restrictions.rb
+++ b/lib/bitbucket_rest_api/repos/branch_restrictions.rb
@@ -1,0 +1,37 @@
+# encoding: utf-8
+
+module BitBucket
+  class Repos::BranchRestrictions < API
+
+    VALID_KEY_PARAM_NAMES = %w(kind pattern).freeze
+
+    # Gets the branch_restrictions information associated with a repository.
+    #
+    # = Parameters
+    # *<tt>kind</tt> - Branch restrictions of this type
+    # *<tt>pattern</tt> - Branch restrictions applied to branches of this pattern
+    #
+    # = Examples
+    #  bitbucket = BitBucket.new
+    #  bitbucket.repos.branch_restrictions.list 'user-name', 'repo-name'
+    #  bitbucket.repos.branch_restrictions.list 'user-name', 'repo-name', 'master'
+    #  bitbucket.repos.branch_restrictions.list 'user-name', 'repo-name' { |key| ... }
+    #  bitbucket.repos.branch_restrictions.list 'user-name', 'repo-name', nil,
+    #    "kind" => "...",
+    #    "pattern" =>  "..."
+    #
+    def list(user_name, repo_name, params={})
+      _update_user_repo_params(user_name, repo_name)
+      _validate_user_repo_params(user, repo) unless user? && repo?
+      normalize! params
+      filter! VALID_KEY_PARAM_NAMES, params
+
+      path = "/2.0/repositories/#{user}/#{repo.downcase}/branch-restrictions"
+      response = get_request(path, params)
+      return response unless block_given?
+      response.each { |el| yield el }
+    end
+    alias :all :list
+
+  end # Repos::BranchRestrictions
+end # BitBucket

--- a/lib/bitbucket_rest_api/repos/changesets.rb
+++ b/lib/bitbucket_rest_api/repos/changesets.rb
@@ -28,7 +28,7 @@ module BitBucket
       normalize! params
       filter! %w[ limit start], params
 
-      response = get_request("/1.0/repositories/#{user}/#{repo.downcase}/changesets", params)
+      response = get_request("/2.0/repositories/#{user}/#{repo.downcase}/changesets", params)
       return response unless block_given?
       response.each { |el| yield el }
     end
@@ -46,7 +46,7 @@ module BitBucket
       _validate_presence_of sha
       normalize! params
 
-      get_request("/1.0/repositories/#{user}/#{repo.downcase}/changesets/#{sha}", params)
+      get_request("/2.0/repositories/#{user}/#{repo.downcase}/changesets/#{sha}", params)
     end
     alias :find :get
 

--- a/lib/bitbucket_rest_api/repos/following.rb
+++ b/lib/bitbucket_rest_api/repos/following.rb
@@ -15,7 +15,7 @@ module BitBucket
       _validate_user_repo_params(user, repo) unless user? && repo?
       normalize! params
 
-      response = get_request("/1.0/repositories/#{user}/#{repo.downcase}/followers/", params)
+      response = get_request("/2.0/repositories/#{user}/#{repo.downcase}/followers/", params)
       return response unless block_given?
       response.each { |el| yield el }
     end
@@ -30,7 +30,7 @@ module BitBucket
       params = args.extract_options!
       normalize! params
 
-      response = get_request("/1.0/user/follows", params)
+      response = get_request("/2.0/user/follows", params)
       return response unless block_given?
       response.each { |el| yield el }
     end

--- a/lib/bitbucket_rest_api/repos/forks.rb
+++ b/lib/bitbucket_rest_api/repos/forks.rb
@@ -61,7 +61,7 @@ module BitBucket
       assert_required_keys(REQUIRED_KEY_PARAM_NAMES, params)
       filter! VALID_REPO_OPTIONS, params
 
-      post_request("/1.0/repositories/#{user}/#{repo.downcase}/fork", params)
+      post_request("/2.0/repositories/#{user}/#{repo.downcase}/fork", params)
     end
 
 

--- a/lib/bitbucket_rest_api/repos/keys.rb
+++ b/lib/bitbucket_rest_api/repos/keys.rb
@@ -17,7 +17,7 @@ module BitBucket
       _validate_user_repo_params(user, repo) unless user? && repo?
       normalize! params
 
-      response = get_request("/1.0/repositories/#{user}/#{repo}/deploy-keys/", params)
+      response = get_request("/2.0/repositories/#{user}/#{repo}/deploy-keys/", params)
       return response unless block_given?
       response.each { |el| yield el }
     end
@@ -43,7 +43,7 @@ module BitBucket
       assert_required_keys(VALID_KEY_PARAM_NAMES, params)
 
       options = { headers: { "Content-Type" => "application/json" } }
-      post_request("/1.0/repositories/#{user}/#{repo}/deploy-keys/", params, options)
+      post_request("/2.0/repositories/#{user}/#{repo}/deploy-keys/", params, options)
     end
 
     # Edit a key
@@ -66,7 +66,7 @@ module BitBucket
       normalize! params
       filter! VALID_KEY_PARAM_NAMES, params
 
-      put_request("/1.0/repositories/#{user}/#{repo}/deploy-keys/#{key_id}", params)
+      put_request("/2.0/repositories/#{user}/#{repo}/deploy-keys/#{key_id}", params)
     end
 
     # Delete key
@@ -81,7 +81,7 @@ module BitBucket
       _validate_presence_of key_id
       normalize! params
 
-      delete_request("/1.0/repositories/#{user}/#{repo}/deploy-keys/#{key_id}", params)
+      delete_request("/2.0/repositories/#{user}/#{repo}/deploy-keys/#{key_id}", params)
     end
 
   end # Repos::Keys

--- a/lib/bitbucket_rest_api/repos/pipelines.rb
+++ b/lib/bitbucket_rest_api/repos/pipelines.rb
@@ -1,0 +1,45 @@
+# encoding: utf-8
+
+module BitBucket
+  class Repos::Pipelines < API
+    # Gets the pipelines information associated with a repository.
+    #
+    # = Examples
+    #  bitbucket = BitBucket.new
+    #  bitbucket.repos.pipelines.list 'user-name', 'repo-name'
+    #  bitbucket.repos.pipelines.list 'user-name', 'repo-name', 'master'
+    #  bitbucket.repos.pipelines.list 'user-name', 'repo-name' { |key| ... }
+    #
+    def list(user_name, repo_name, params={})
+      _update_user_repo_params(user_name, repo_name)
+      _validate_user_repo_params(user, repo) unless user? && repo?
+      normalize! params
+
+      path = "/2.0/repositories/#{user}/#{repo.downcase}/pipelines/"
+      response = get_request(path, params)
+      return response unless block_given?
+      response.each { |el| yield el }
+    end
+    alias :all :list
+
+    # Gets the pipelines config information associated with a repository.
+    #
+    # = Examples
+    #  bitbucket = BitBucket.new
+    #  bitbucket.repos.pipelines.config 'user-name', 'repo-name'
+    #  bitbucket.repos.pipelines.config 'user-name', 'repo-name', 'master'
+    #  bitbucket.repos.pipelines.config 'user-name', 'repo-name' { |key| ... }
+    #
+    def config(user_name, repo_name, params={})
+      _update_user_repo_params(user_name, repo_name)
+      _validate_user_repo_params(user, repo) unless user? && repo?
+      normalize! params
+
+      path = "/2.0/repositories/#{user}/#{repo.downcase}/pipelines_config"
+      response = get_request(path, params)
+      return response unless block_given?
+      response.each { |el| yield el }
+    end
+
+  end # Repos::Pipelines
+end # BitBucket

--- a/lib/bitbucket_rest_api/repos/pull_request.rb
+++ b/lib/bitbucket_rest_api/repos/pull_request.rb
@@ -33,7 +33,7 @@ module BitBucket
       _validate_user_repo_params(user, repo) unless user? && repo?
       normalize! params
 
-      response = get_request("/1.0/repositories/#{user}/#{repo.downcase}/pullrequests/#{pull_request_id}/participants", params)
+      response = get_request("/2.0/repositories/#{user}/#{repo.downcase}/pullrequests/#{pull_request_id}/participants", params)
       return response unless block_given?
       response.each { |el| yield el }
     end

--- a/lib/bitbucket_rest_api/repos/services.rb
+++ b/lib/bitbucket_rest_api/repos/services.rb
@@ -17,7 +17,7 @@ module BitBucket
       _validate_user_repo_params(user, repo) unless user? && repo?
       normalize! params
 
-      response = get_request("/1.0/repositories/#{user}/#{repo.downcase}/services", params)
+      response = get_request("/2.0/repositories/#{user}/#{repo.downcase}/services", params)
       return response unless block_given?
       response.each { |el| yield el }
     end
@@ -35,7 +35,7 @@ module BitBucket
       _validate_presence_of(service_id)
       normalize! params
 
-      get_request("/1.0/repositories/#{user}/#{repo.downcase}/services/#{service_id}", params)
+      get_request("/2.0/repositories/#{user}/#{repo.downcase}/services/#{service_id}", params)
     end
     alias :find :get
 
@@ -58,7 +58,7 @@ module BitBucket
       normalize! params
       assert_required_keys(REQUIRED_KEY_PARAM_NAMES, params)
 
-      post_request("/1.0/repositories/#{user}/#{repo.downcase}/services", params)
+      post_request("/2.0/repositories/#{user}/#{repo.downcase}/services", params)
     end
 
     # Edit a service
@@ -81,7 +81,7 @@ module BitBucket
 
       normalize! params
 
-      put_request("/1.0/repositories/#{user}/#{repo.downcase}/services/#{service_id}", params)
+      put_request("/2.0/repositories/#{user}/#{repo.downcase}/services/#{service_id}", params)
     end
 
     # Delete service
@@ -96,7 +96,7 @@ module BitBucket
       _validate_presence_of(service_id)
       normalize! params
 
-      delete_request("/1.0/repositories/#{user}/#{repo.downcase}/services/#{service_id}", params)
+      delete_request("/2.0/repositories/#{user}/#{repo.downcase}/services/#{service_id}", params)
     end
 
   end # Repos::Keys

--- a/lib/bitbucket_rest_api/repos/sources.rb
+++ b/lib/bitbucket_rest_api/repos/sources.rb
@@ -14,7 +14,7 @@ module BitBucket
       _validate_user_repo_params(user, repo) unless user? && repo?
       _validate_presence_of(sha, path)
 
-      get_request("/1.0/repositories/#{user}/#{repo.downcase}/src/#{sha}/#{path}")
+      get_request("/2.0/repositories/#{user}/#{repo.downcase}/src/#{sha}/#{path}")
     end
     alias :all :list
 
@@ -31,7 +31,7 @@ module BitBucket
       _validate_user_repo_params(user, repo) unless user? && repo?
       _validate_presence_of(sha, path)
 
-      get_request("/1.0/repositories/#{user}/#{repo.downcase}/raw/#{sha}/#{path}")
+      get_request("/2.0/repositories/#{user}/#{repo.downcase}/raw/#{sha}/#{path}")
     end
     alias :find :get
 

--- a/lib/bitbucket_rest_api/response/mashify.rb
+++ b/lib/bitbucket_rest_api/response/mashify.rb
@@ -7,7 +7,7 @@ module BitBucket
     dependency 'hashie/mash'
 
     define_parser do |body|
-      ::Hashie::Mash.new body
+      ::Hashie::Mash.quiet.new body
     end
 
     def parse(body)

--- a/lib/bitbucket_rest_api/user.rb
+++ b/lib/bitbucket_rest_api/user.rb
@@ -26,7 +26,7 @@ module BitBucket
     #  bitbucket.user_api.profile
     #
     def profile
-      get_request("/1.0/user")
+      get_request("/2.0/user")
     end
 
 
@@ -48,14 +48,14 @@ module BitBucket
       normalize! params
       filter! DEFAULT_USER_OPTIONS, params
 
-      put_request("/1.0/user", DEFAULT_USER_OPTIONS.merge(params))
+      put_request("/2.0/user", DEFAULT_USER_OPTIONS.merge(params))
 
     end
 
 
     # GET a list of user privileges
     def privileges
-      get_request("/1.0/user/privileges")
+      get_request("/2.0/user/privileges")
     end
 
 
@@ -66,7 +66,7 @@ module BitBucket
     # if the repository is a fork of another repository.
     # An account always "follows" its own repositories.
     def follows
-      get_request("/1.0/user/follows")
+      get_request("/2.0/user/follows")
     end
 
 
@@ -75,7 +75,7 @@ module BitBucket
     # or has at least read access to.
     # Use this if you're looking for a full list of all of the repositories associated with a user.
     def repositories
-      get_request("/1.0/user/repositories")
+      get_request("/2.0/user/repositories")
     end
 
     alias :repos :repositories
@@ -86,7 +86,7 @@ module BitBucket
     # Gets a list of the repositories the account follows.
     # This is the same list that appears on the Following tab on your account dashboard.
     def overview
-      get_request("/1.0/user/repositories/overview")
+      get_request("/2.0/user/repositories/overview")
     end
 
 
@@ -94,7 +94,7 @@ module BitBucket
     # GET the list of repositories on the dashboard
     # Gets the repositories list from the account's dashboard.
     def dashboard
-      get_request("/1.0/user/repositories/dashboard")
+      get_request("/2.0/user/repositories/dashboard")
     end
 
   end # User

--- a/lib/bitbucket_rest_api/users/account.rb
+++ b/lib/bitbucket_rest_api/users/account.rb
@@ -11,43 +11,43 @@ module BitBucket
     # GET the account profile
     # 
     def profile(accountname)
-      response = get_request("/1.0/users/#{accountname}")
+      response = get_request("/2.0/users/#{accountname}")
     end
 
     # GET the account plan
     def plan(accountname)
-      response = get_request("/1.0/users/#{accountname}/plan")
+      response = get_request("/2.0/users/#{accountname}/plan")
     end
 
     # GET the emails
     def emails(accountname)
-      response = get_request("/1.0/users/#{accountname}/emails")
+      response = get_request("/2.0/users/#{accountname}/emails")
     end
 
     # GET the followers
     def followers(accountname)
-      response = get_request("/1.0/users/#{accountname}/followers")
+      response = get_request("/2.0/users/#{accountname}/followers")
     end
 
     # GET the events
     def events(accountname)
-      response = get_request("/1.0/users/#{accountname}/events")
+      response = get_request("/2.0/users/#{accountname}/events")
     end
 
     #GET the keys
     def keys(accountname)
-      response = get_request("/1.0/users/#{accountname}/ssh-keys")
+      response = get_request("/2.0/users/#{accountname}/ssh-keys")
     end
 
     #POST a new key
     # params should be in format {key: "", label:""}
     def new_key(accountname, params)
-      response = post_request("/1.0/users/#{accountname}/ssh-keys/", params)
+      response = post_request("/2.0/users/#{accountname}/ssh-keys/", params)
     end
 
     #DELETE a key
     def delete_key(accountname, key_id)
-      response = delete_request("/1.0/users/#{accountname}/ssh-keys/#{key_id}")
+      response = delete_request("/2.0/users/#{accountname}/ssh-keys/#{key_id}")
     end
   end # Users::Account
 end # BitBucket

--- a/lib/bitbucket_rest_api/validations/token.rb
+++ b/lib/bitbucket_rest_api/validations/token.rb
@@ -13,6 +13,7 @@ module BitBucket
           'get /user/following',
           'get /user/keys',
           'get /user/repos',
+          'get /user/workspaces',
           'patch /user',
           'post /user/emails',
           'post /user/keys',

--- a/lib/bitbucket_rest_api/version.rb
+++ b/lib/bitbucket_rest_api/version.rb
@@ -4,7 +4,7 @@ module BitBucket
   module VERSION
     MAJOR = 0
     MINOR = 1
-    PATCH = 7
+    PATCH = 8
 
     STRING = [MAJOR, MINOR, PATCH].compact.join('.')
   end

--- a/lib/bitbucket_rest_api/workspaces.rb
+++ b/lib/bitbucket_rest_api/workspaces.rb
@@ -25,7 +25,7 @@ module BitBucket
       _merge_user_into_params!(params)
       params.merge!('pagelen' => 100) unless params.has_key?('pagelen')
       
-      filter! %w[ pagelen ], params
+      filter! %w[ pagelen role ], params
 
       response = get_request("/2.0/workspaces", params)
 

--- a/lib/bitbucket_rest_api/workspaces.rb
+++ b/lib/bitbucket_rest_api/workspaces.rb
@@ -1,0 +1,47 @@
+# encoding: utf-8
+
+module BitBucket
+  class Workspaces < API
+    extend AutoloadHelper
+
+    # Load all the modules after initializing Repos to avoid superclass mismatch
+    autoload_all 'bitbucket_rest_api/workspaces',
+                 :Members       => 'members'
+
+    # Creates new Workspaces API
+    def initialize(options = { })
+      super(options)
+    end
+
+    # List workspaces for the authenticated user
+    #
+    # = Examples
+    #   bitbucket = BitBucket.new :oauth_token => '...', :oauth_secret => '...'
+    #   bitbucket.workspaces.list
+    #   bitbucket.workspaces.list { |workspace| ... }
+    def list(*args)
+      params = args.extract_options!
+      normalize! params
+      _merge_user_into_params!(params)
+      params.merge!('pagelen' => 100) unless params.has_key?('pagelen')
+      
+      filter! %w[ pagelen ], params
+
+      response = get_request("/2.0/workspaces", params)
+
+      response = response[:values]
+      return response unless block_given?
+      response.each { |el| yield el }
+    end
+    alias :all :list
+
+    def permissions(workspace_slug)
+      get_request("/2.0/workspaces/#{workspace_slug}/permissions")
+    end
+
+    # Access to Workspaces::Members API
+    def members
+      @members ||= ApiFactory.new 'Workspaces::Members'
+    end
+  end # Workspaces
+end # BitBucket

--- a/lib/bitbucket_rest_api/workspaces/members.rb
+++ b/lib/bitbucket_rest_api/workspaces/members.rb
@@ -1,0 +1,17 @@
+# encoding: utf-8
+
+module BitBucket
+  class Workspaces::Members < API
+
+    # API about workspaces/members , please refer to 
+    # https://developer.atlassian.com/bitbucket/api/2/reference/resource/workspaces/%7Bworkspace%7D/members
+    #  
+
+
+    # GET the workspace members
+    # 
+    def list(workspace)
+      get_request("/2.0/workspaces/#{workspace}/members")
+    end
+  end # Workspaces::Members
+end # BitBucket

--- a/spec/bitbucket_rest_api/invitations_spec.rb
+++ b/spec/bitbucket_rest_api/invitations_spec.rb
@@ -7,7 +7,7 @@ describe BitBucket::Invitations do
     before do
       expect(subject).to receive(:request).with(
         :post,
-        "/1.0/invitations/mock_username/mock_repo/mock_email_address",
+        "/2.0/invitations/mock_username/mock_repo/mock_email_address",
         { :permission => 'read' },
         {}
       )

--- a/spec/bitbucket_rest_api/issues/comments_spec.rb
+++ b/spec/bitbucket_rest_api/issues/comments_spec.rb
@@ -7,7 +7,7 @@ describe BitBucket::Issues::Comments do
     before do
       expect(comments).to receive(:request).with(
         :get,
-        '/1.0/repositories/mock_username/mock_repo/issues/mock_issue_id/comments/',
+        '/2.0/repositories/mock_username/mock_repo/issues/mock_issue_id/comments/',
         {},
         {}
       ).and_return(['comment1', 'comment2', 'comment3'])
@@ -30,7 +30,7 @@ describe BitBucket::Issues::Comments do
     before do
       expect(comments).to receive(:request).with(
         :get,
-        '/1.0/repositories/mock_username/mock_repo/issues/comments/mock_comment_id',
+        '/2.0/repositories/mock_username/mock_repo/issues/comments/mock_comment_id',
         {},
         {}
       )
@@ -45,7 +45,7 @@ describe BitBucket::Issues::Comments do
     before do
       expect(comments).to receive(:request).with(
         :post,
-        '/1.0/repositories/mock_username/mock_repo/issues/mock_issue_id/comments/',
+        '/2.0/repositories/mock_username/mock_repo/issues/mock_issue_id/comments/',
         {'content' => 'mock_comment'},
         {}
       )
@@ -60,7 +60,7 @@ describe BitBucket::Issues::Comments do
     before do
       expect(comments).to receive(:request).with(
         :put,
-        '/1.0/repositories/mock_username/mock_repo/issues/comments/mock_comment_id',
+        '/2.0/repositories/mock_username/mock_repo/issues/comments/mock_comment_id',
         {'content' => 'new_mock_comment'},
         {}
       )
@@ -75,7 +75,7 @@ describe BitBucket::Issues::Comments do
     before do
       expect(comments).to receive(:request).with(
         :delete,
-        '/1.0/repositories/mock_username/mock_repo/issues/comments/mock_comment_id',
+        '/2.0/repositories/mock_username/mock_repo/issues/comments/mock_comment_id',
         {},
         {}
       )

--- a/spec/bitbucket_rest_api/issues/components_spec.rb
+++ b/spec/bitbucket_rest_api/issues/components_spec.rb
@@ -7,7 +7,7 @@ describe BitBucket::Issues::Components do
     before do
       expect(subject).to receive(:request).with(
         :get,
-        '/1.0/repositories/mock_username/mock_repo/issues/components',
+        '/2.0/repositories/mock_username/mock_repo/issues/components',
         {},
         {}
       ).and_return(['component1', 'component2', 'component3'])
@@ -30,7 +30,7 @@ describe BitBucket::Issues::Components do
     before do
       expect(subject).to receive(:request).with(
         :get,
-        '/1.0/repositories/mock_username/mock_repo/issues/components/mock_component_id',
+        '/2.0/repositories/mock_username/mock_repo/issues/components/mock_component_id',
         {},
         {}
       )
@@ -45,7 +45,7 @@ describe BitBucket::Issues::Components do
     before do
       expect(subject).to receive(:request).with(
         :post,
-        '/1.0/repositories/mock_username/mock_repo/issues/components',
+        '/2.0/repositories/mock_username/mock_repo/issues/components',
         { 'name' => 'mock_name' },
         {}
       )
@@ -60,7 +60,7 @@ describe BitBucket::Issues::Components do
     before do
       expect(subject).to receive(:request).with(
         :put,
-        '/1.0/repositories/mock_username/mock_repo/issues/components/mock_component_id',
+        '/2.0/repositories/mock_username/mock_repo/issues/components/mock_component_id',
         { 'name' => 'mock_name' },
         {}
       )
@@ -75,7 +75,7 @@ describe BitBucket::Issues::Components do
     before do
       expect(subject).to receive(:request).with(
         :delete,
-        '/1.0/repositories/mock_username/mock_repo/issues/components/mock_component_id',
+        '/2.0/repositories/mock_username/mock_repo/issues/components/mock_component_id',
         {},
         {}
       )

--- a/spec/bitbucket_rest_api/issues/milestones_spec.rb
+++ b/spec/bitbucket_rest_api/issues/milestones_spec.rb
@@ -7,7 +7,7 @@ describe BitBucket::Issues::Milestones do
     before do
       expect(subject).to receive(:request).with(
         :get,
-        '/1.0/repositories/mock_username/mock_repo/issues/milestones',
+        '/2.0/repositories/mock_username/mock_repo/issues/milestones',
         {},
         {}
       ).and_return(['milsetone1', 'milestone2', 'milestone3'])
@@ -30,7 +30,7 @@ describe BitBucket::Issues::Milestones do
     before do
       expect(subject).to receive(:request).with(
         :get,
-        '/1.0/repositories/mock_username/mock_repo/issues/milestones/mock_milestone_id',
+        '/2.0/repositories/mock_username/mock_repo/issues/milestones/mock_milestone_id',
         {},
         {}
       )
@@ -45,7 +45,7 @@ describe BitBucket::Issues::Milestones do
     before do
       expect(subject).to receive(:request).with(
         :post,
-        '/1.0/repositories/mock_username/mock_repo/issues/milestones',
+        '/2.0/repositories/mock_username/mock_repo/issues/milestones',
         { 'name' => 'mock_name' },
         {}
       )
@@ -60,7 +60,7 @@ describe BitBucket::Issues::Milestones do
     before do
       expect(subject).to receive(:request).with(
         :put,
-        '/1.0/repositories/mock_username/mock_repo/issues/milestones/mock_milestone_id',
+        '/2.0/repositories/mock_username/mock_repo/issues/milestones/mock_milestone_id',
         { 'name' => 'mock_name' },
         {}
       )
@@ -75,7 +75,7 @@ describe BitBucket::Issues::Milestones do
     before do
       expect(subject).to receive(:request).with(
         :delete,
-        '/1.0/repositories/mock_username/mock_repo/issues/milestones/mock_milestone_id',
+        '/2.0/repositories/mock_username/mock_repo/issues/milestones/mock_milestone_id',
         {},
         {}
       )

--- a/spec/bitbucket_rest_api/issues_spec.rb
+++ b/spec/bitbucket_rest_api/issues_spec.rb
@@ -8,7 +8,7 @@ describe BitBucket::Issues do
     before do
       expect(issue).to receive(:request).with(
         :post,
-        '/1.0/repositories/mock_username/mock_repo/issues/',
+        '/2.0/repositories/mock_username/mock_repo/issues/',
         { 'title' => 'mock_issue' },
         {}
       )
@@ -23,7 +23,7 @@ describe BitBucket::Issues do
     before do
       expect(issue).to receive(:request).with(
         :put,
-        '/1.0/repositories/mock_username/mock_repo/issues/1/',
+        '/2.0/repositories/mock_username/mock_repo/issues/1/',
         { 'title' => 'new_title' },
         {}
       )
@@ -38,7 +38,7 @@ describe BitBucket::Issues do
     before do
       expect(issue).to receive(:request).with(
         :get,
-        '/1.0/repositories/mock_username/mock_repo/issues/1',
+        '/2.0/repositories/mock_username/mock_repo/issues/1',
         {},
         {}
       )
@@ -53,7 +53,7 @@ describe BitBucket::Issues do
     before do
       expect(issue).to receive(:request).with(
         :delete,
-        '/1.0/repositories/mock_username/mock_repo/issues/1',
+        '/2.0/repositories/mock_username/mock_repo/issues/1',
         {},
         {}
       )
@@ -68,7 +68,7 @@ describe BitBucket::Issues do
     before do
       expect(issue).to receive(:request).with(
         :get,
-        '/1.0/repositories/mock_username/mock_repo/issues',
+        '/2.0/repositories/mock_username/mock_repo/issues',
         {},
         {}
       ).and_return(OpenStruct.new(:issues => [])).twice

--- a/spec/bitbucket_rest_api/repos/changesets_spec.rb
+++ b/spec/bitbucket_rest_api/repos/changesets_spec.rb
@@ -7,7 +7,7 @@ describe BitBucket::Repos::Changesets do
     before do
       expect(changesets).to receive(:request).with(
         :get,
-        '/1.0/repositories/mock_username/mock_repo/changesets',
+        '/2.0/repositories/mock_username/mock_repo/changesets',
         {},
         {}
       ).and_return(['changset1', 'changeset2', 'changeset3'])
@@ -30,7 +30,7 @@ describe BitBucket::Repos::Changesets do
     before do
       expect(changesets).to receive(:request).with(
         :get,
-        '/1.0/repositories/mock_username/mock_repo/changesets/test_sha',
+        '/2.0/repositories/mock_username/mock_repo/changesets/test_sha',
         {},
         {}
       )

--- a/spec/bitbucket_rest_api/repos/following_spec.rb
+++ b/spec/bitbucket_rest_api/repos/following_spec.rb
@@ -7,7 +7,7 @@ describe BitBucket::Repos::Following do
     before do
       expect(following).to receive(:request).with(
         :get,
-        '/1.0/repositories/mock_username/mock_repo/followers/',
+        '/2.0/repositories/mock_username/mock_repo/followers/',
         {},
         {}
       ).and_return(['follower1', 'follower2', 'follower3'])
@@ -31,7 +31,7 @@ describe BitBucket::Repos::Following do
     before do
       expect(following).to receive(:request).with(
         :get,
-        '/1.0/user/follows',
+        '/2.0/user/follows',
         {},
         {}
       ).and_return(['followed1', 'followed2', 'followed3'])

--- a/spec/bitbucket_rest_api/repos/forks_spec.rb
+++ b/spec/bitbucket_rest_api/repos/forks_spec.rb
@@ -32,7 +32,7 @@ describe BitBucket::Repos::Forks do
     before do
       expect(forks).to receive(:request).with(
         :post,
-        '/1.0/repositories/mock_username/mock_repo/fork',
+        '/2.0/repositories/mock_username/mock_repo/fork',
         { 'name' => 'mock_fork_name'},
         {}
       )

--- a/spec/bitbucket_rest_api/repos/keys_spec.rb
+++ b/spec/bitbucket_rest_api/repos/keys_spec.rb
@@ -6,7 +6,7 @@ describe BitBucket::Repos::Keys do
     before do
       expect(deploy_keys).to receive(:request).with(
         :get,
-        '/1.0/repositories/mock_username/mock_repo/deploy-keys/',
+        '/2.0/repositories/mock_username/mock_repo/deploy-keys/',
         {},
         {}
       ).and_return(['key1', 'key2', 'key3'])
@@ -29,7 +29,7 @@ describe BitBucket::Repos::Keys do
     before do
       expect(deploy_keys).to receive(:request).with(
         :post,
-        '/1.0/repositories/mock_username/mock_repo/deploy-keys/',
+        '/2.0/repositories/mock_username/mock_repo/deploy-keys/',
         { 'key' => 'mock_ssh_key', 'label' => 'mock_label' },
         { headers: {"Content-Type"=>"application/json"} }
       )
@@ -44,7 +44,7 @@ describe BitBucket::Repos::Keys do
     before do
       expect(deploy_keys).to receive(:request).with(
          :put,
-         '/1.0/repositories/mock_username/mock_repo/deploy-keys/1',
+         '/2.0/repositories/mock_username/mock_repo/deploy-keys/1',
          { 'key' => 'mock_ssh_key', 'label' => 'mock_label' },
          {}
        )
@@ -59,7 +59,7 @@ describe BitBucket::Repos::Keys do
     before do
       expect(deploy_keys).to receive(:request).with(
         :delete,
-        '/1.0/repositories/mock_username/mock_repo/deploy-keys/mock_id',
+        '/2.0/repositories/mock_username/mock_repo/deploy-keys/mock_id',
         { 'key' => 'mock_ssh_key', 'label' => 'mock_label' },
         {}
       )

--- a/spec/bitbucket_rest_api/repos/pull_request_spec.rb
+++ b/spec/bitbucket_rest_api/repos/pull_request_spec.rb
@@ -29,7 +29,7 @@ describe BitBucket::Repos::PullRequest do
     before do
       expect(subject).to receive(:request).with(
         :get,
-        "/1.0/repositories/mock_user/mock_repo/pullrequests/mock_pull_request_id/participants",
+        "/2.0/repositories/mock_user/mock_repo/pullrequests/mock_pull_request_id/participants",
         {},
         {}
       ).and_return(['participant1', 'participant2', 'participant3'])

--- a/spec/bitbucket_rest_api/repos/sources_spec.rb
+++ b/spec/bitbucket_rest_api/repos/sources_spec.rb
@@ -19,7 +19,7 @@ describe BitBucket::Repos::Sources do
       before do
         expect(subject).to receive(:request).with(
           :get,
-          '/1.0/repositories/mock_username/mock_repo/src/moch_sha/',
+          '/2.0/repositories/mock_username/mock_repo/src/moch_sha/',
           {},
           {}
         )
@@ -34,7 +34,7 @@ describe BitBucket::Repos::Sources do
       before do
         expect(subject).to receive(:request).with(
           :get,
-          '/1.0/repositories/mock_username/mock_repo/src/moch_sha/app/controller',
+          '/2.0/repositories/mock_username/mock_repo/src/moch_sha/app/controller',
           {},
           {}
         )
@@ -63,7 +63,7 @@ describe BitBucket::Repos::Sources do
       before do
         expect(subject).to receive(:request).with(
           :get,
-          '/1.0/repositories/mock_username/mock_repo/raw/moch_sha/app/assets/images/logo.jpg',
+          '/2.0/repositories/mock_username/mock_repo/raw/moch_sha/app/assets/images/logo.jpg',
           {},
           {}
         )

--- a/spec/bitbucket_rest_api/repos_spec.rb
+++ b/spec/bitbucket_rest_api/repos_spec.rb
@@ -15,7 +15,7 @@ describe BitBucket::Repos do
     before do
       expect(repo).to receive(:request).with(
         :post,
-        '/1.0/repositories/',
+        '/2.0/repositories/',
         BitBucket::Repos::DEFAULT_REPO_OPTIONS.merge({ 'owner' => 'mock_owner', 'name' => 'mock_repo' }),
         {}
       )
@@ -30,7 +30,7 @@ describe BitBucket::Repos do
     before do
       expect(repo).to receive(:request).with(
         :delete,
-        '/1.0/repositories/mock_username/mock_repo',
+        '/2.0/repositories/mock_username/mock_repo',
         {},
         {}
       )
@@ -46,7 +46,7 @@ describe BitBucket::Repos do
     before do
       expect(repo).to receive(:request).with(
         :get,
-        '/1.0/repositories/mock_username/mock_repo/branches/',
+        '/2.0/repositories/mock_username/mock_repo/branches/',
         {},
         {}
       ).and_return(['branch1', 'branch2', 'branch3'])
@@ -69,7 +69,7 @@ describe BitBucket::Repos do
     before do
       expect(repo).to receive(:request).with(
         :put,
-        '/1.0/repositories/mock_username/mock_repo/',
+        '/2.0/repositories/mock_username/mock_repo/',
         BitBucket::Repos::DEFAULT_REPO_OPTIONS.merge({ 'owner' => 'mock_owner' }),
         {}
       )
@@ -85,7 +85,7 @@ describe BitBucket::Repos do
     before do
       expect(repo).to receive(:request).with(
         :get,
-        '/1.0/repositories/mock_username/mock_repo',
+        '/2.0/repositories/mock_username/mock_repo',
         {},
         {}
       )
@@ -124,7 +124,7 @@ describe BitBucket::Repos do
     before do
       expect(repo).to receive(:request).with(
         :get,
-        '/1.0/repositories/mock_username/mock_repo/tags/',
+        '/2.0/repositories/mock_username/mock_repo/tags/',
         {},
         {}
       ).and_return(['tag1', 'tag2' ,'tag3'])

--- a/spec/bitbucket_rest_api/request_spec.rb
+++ b/spec/bitbucket_rest_api/request_spec.rb
@@ -17,7 +17,7 @@ describe BitBucket::Request do
       end
 
       it "supports get" do
-        stub_request(:get, "https://api.bitbucket.org/1.0/endpoint").
+        stub_request(:get, "https://api.bitbucket.org/2.0/endpoint").
          with(:headers => {
           'Accept' => '*/*',
           'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
@@ -25,11 +25,11 @@ describe BitBucket::Request do
           'User-Agent' => 'Faraday v0.9.2'
           })
 
-        fake_api.new.request(:get, '/1.0/endpoint', {}, {})
+        fake_api.new.request(:get, '/2.0/endpoint', {}, {})
       end
 
       it "supports put" do
-        stub_request(:put, "https://api.bitbucket.org/1.0/endpoint").
+        stub_request(:put, "https://api.bitbucket.org/2.0/endpoint").
          with(:body => "{\"data\":{\"key\":\"value\"}}",
           :headers => {
             'Accept' => '*/*',
@@ -38,11 +38,11 @@ describe BitBucket::Request do
             'User-Agent' => 'Faraday v0.9.2'
           })
 
-        fake_api.new.request(:put, '/1.0/endpoint', { 'data' => { 'key' => 'value'} }, {})
+        fake_api.new.request(:put, '/2.0/endpoint', { 'data' => { 'key' => 'value'} }, {})
       end
 
       it "supports patch" do
-        stub_request(:patch, "https://api.bitbucket.org/1.0/endpoint").
+        stub_request(:patch, "https://api.bitbucket.org/2.0/endpoint").
          with(:body => "{\"data\":{\"key\":\"value\"}}",
           :headers => {
             'Accept' => '*/*',
@@ -51,21 +51,21 @@ describe BitBucket::Request do
             'User-Agent' => 'Faraday v0.9.2'
           })
 
-        fake_api.new.request(:patch, '/1.0/endpoint', { 'data' => { 'key' => 'value'} }, {})
+        fake_api.new.request(:patch, '/2.0/endpoint', { 'data' => { 'key' => 'value'} }, {})
       end
 
       it "supports delete" do
-        stub_request(:delete, "https://api.bitbucket.org/1.0/endpoint").
+        stub_request(:delete, "https://api.bitbucket.org/2.0/endpoint").
          with(:headers => {
           'Accept' => '*/*',
           'Authorization' => 'Bearer 12345',
           'User-Agent' => 'Faraday v0.9.2'
           })
-        fake_api.new.request(:delete, '/1.0/endpoint', {}, {})
+        fake_api.new.request(:delete, '/2.0/endpoint', {}, {})
       end
 
       it "supports post" do
-        stub_request(:post, "https://api.bitbucket.org/1.0/endpoint").
+        stub_request(:post, "https://api.bitbucket.org/2.0/endpoint").
          with(:body => "{\"data\":{\"key\":\"value\"}}",
           :headers => {
             'Accept' => '*/*',
@@ -74,7 +74,7 @@ describe BitBucket::Request do
             'User-Agent' => 'Faraday v0.9.2'
           })
 
-        fake_api.new.request(:post, '/1.0/endpoint', { 'data' => { 'key' => 'value'} }, {})
+        fake_api.new.request(:post, '/2.0/endpoint', { 'data' => { 'key' => 'value'} }, {})
       end
     end
   end

--- a/spec/bitbucket_rest_api/user_spec.rb
+++ b/spec/bitbucket_rest_api/user_spec.rb
@@ -17,7 +17,7 @@ describe BitBucket::User do
 
   describe '#profile' do
     it 'sends the request to the right url' do
-      expect(@user).to receive(:request).with(:get, '/1.0/user', {}, {})
+      expect(@user).to receive(:request).with(:get, '/2.0/user', {}, {})
       @user.profile
     end
   end
@@ -28,49 +28,49 @@ describe BitBucket::User do
     end
 
     it 'sends the request to the right url' do
-      expect(@user).to receive(:request).with(:put, '/1.0/user', params, {})
+      expect(@user).to receive(:request).with(:put, '/2.0/user', params, {})
       @user.update(params)
     end
   end
 
   describe '#privileges' do
     it 'sends the request to the right url' do
-      expect(@user).to receive(:request).with(:get, '/1.0/user/privileges', {}, {})
+      expect(@user).to receive(:request).with(:get, '/2.0/user/privileges', {}, {})
       @user.privileges
     end
   end
 
   describe '#follows' do
     it 'sends the request to the right url' do
-      expect(@user).to receive(:request).with(:get, '/1.0/user/follows', {}, {})
+      expect(@user).to receive(:request).with(:get, '/2.0/user/follows', {}, {})
       @user.follows
     end
   end
 
   describe '#repositories' do
     it 'sends the request to the right url' do
-      expect(@user).to receive(:request).with(:get, '/1.0/user/repositories', {}, {})
+      expect(@user).to receive(:request).with(:get, '/2.0/user/repositories', {}, {})
       @user.repositories
     end
   end
 
   describe '#repos' do
     it 'sends the request to the right url' do
-      expect(@user).to receive(:request).with(:get, '/1.0/user/repositories', {}, {})
+      expect(@user).to receive(:request).with(:get, '/2.0/user/repositories', {}, {})
       @user.repos
     end
   end
 
   describe '#overview' do
     it 'sends the request to the right url' do
-      expect(@user).to receive(:request).with(:get, '/1.0/user/repositories/overview', {}, {})
+      expect(@user).to receive(:request).with(:get, '/2.0/user/repositories/overview', {}, {})
       @user.overview
     end
   end
 
   describe '#dashboard' do
     it 'sends the request to the right url' do
-      expect(@user).to receive(:request).with(:get, '/1.0/user/repositories/dashboard', {}, {})
+      expect(@user).to receive(:request).with(:get, '/2.0/user/repositories/dashboard', {}, {})
       @user.dashboard
     end
   end


### PR DESCRIPTION
To make this gem compatible with other gems depending on newer versions of faraday.

I've fixed some endpoints and added support for some new endpoints. This is working fine within the context of my project. I understand that there maybe some issues with some other APIs. I didn't have enough time to test and fix everything. Let me know if someone would like to co-author this PR.

I was also facing APIs depreciation error. Which I later fixed by changing the APIs version from 1.0 to 2.0. It's working fine for my cases so far. But feel free to point out any errors or contribute to this PR.